### PR TITLE
Update case service to use citizen APIs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.et.syaapi.controllers;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,7 +16,6 @@ import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.et.syaapi.annotation.ApiResponseGroup;
 import uk.gov.hmcts.reform.et.syaapi.enums.CaseEvent;
-import uk.gov.hmcts.reform.et.syaapi.search.Query;
 import uk.gov.hmcts.reform.et.syaapi.service.CaseService;
 
 import java.util.List;
@@ -25,7 +23,6 @@ import javax.validation.constraints.NotNull;
 
 import static org.springframework.http.ResponseEntity.ok;
 import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.AUTHORIZATION;
-import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.ZERO_INTEGER;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseController.java
@@ -54,8 +54,7 @@ public class ManageCaseController {
         @PathVariable String caseType,
         @RequestBody String searchString
     ) {
-        Query query = new Query(QueryBuilders.wrapperQuery(searchString), ZERO_INTEGER);
-        return ok(caseService.getCaseDataByUser(authorization, caseType, query.toString()));
+        return ok(caseService.getCaseDataByUser(authorization, caseType));
     }
 
     @PostMapping("/case-type/{caseType}/event-type/{eventType}/case")

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
@@ -125,7 +125,7 @@ class ManageCaseControllerTest {
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(UserDetails.builder().id(USER_ID).build());
         when(caseService.getCaseDataByUser(
             TEST_SERVICE_AUTH_TOKEN,
-            CASE_TYPE, query.toString()
+            CASE_TYPE
         ))
             .thenReturn(requestCaseDataList);
 

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/ManageCaseControllerTest.java
@@ -4,7 +4,6 @@ import feign.FeignException;
 import feign.Request;
 import feign.RequestTemplate;
 import lombok.SneakyThrows;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -19,7 +18,6 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants;
 import uk.gov.hmcts.reform.et.syaapi.enums.CaseEvent;
 import uk.gov.hmcts.reform.et.syaapi.helper.CaseDetailsConverter;
-import uk.gov.hmcts.reform.et.syaapi.search.Query;
 import uk.gov.hmcts.reform.et.syaapi.service.CaseService;
 import uk.gov.hmcts.reform.et.syaapi.service.VerifyTokenService;
 import uk.gov.hmcts.reform.et.syaapi.utils.ResourceLoader;
@@ -119,7 +117,6 @@ class ManageCaseControllerTest {
     void shouldGetCaseDetailsByUser() {
         // given
         String searchString = "{\"match_all\": {}}";
-        Query query = new Query(QueryBuilders.wrapperQuery(searchString), 0);
 
         when(verifyTokenService.verifyTokenSignature(any())).thenReturn(true);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(UserDetails.builder().id(USER_ID).build());

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.et.syaapi.service;
 
 import lombok.EqualsAndHashCode;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,7 +16,6 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.et.syaapi.client.CcdApiClient;
 import uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants;
 import uk.gov.hmcts.reform.et.syaapi.helper.CaseDetailsConverter;
-import uk.gov.hmcts.reform.et.syaapi.search.Query;
 import uk.gov.hmcts.reform.et.syaapi.utils.ResourceLoader;
 import uk.gov.hmcts.reform.et.syaapi.utils.ResourceUtil;
 import uk.gov.hmcts.reform.et.syaapi.utils.TestConstants;
@@ -41,6 +39,9 @@ class CaseServiceTest {
     private static final String CASE_ID = "TEST_CASE_ID";
     private static final String USER_ID = "TEST_USER_ID";
     private static final String JURISDICTION_ID = "EMPLOYMENT";
+    private static final String USER_EMAIL = "test@gmail.com";
+    private static final String USER_FORENAME = "Joe";
+    private static final String USER_SURNAME = "Bloggs";
 
     private final CaseDetails expectedDetails = ResourceLoader.fromString(
         "responses/caseDetails.json",
@@ -96,15 +97,12 @@ class CaseServiceTest {
 
     @Test
     void shouldGetCaseDetailsbyUser() {
-        String searchString = "{\"match_all\": {}}";
-        Query query = new Query(QueryBuilders.wrapperQuery(searchString), 0);
-
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
             USER_ID,
-            "test@gmail.com",
-            "Joe",
-            "Bloggs",
+            USER_EMAIL,
+            USER_FORENAME,
+            USER_SURNAME,
             null
         ));
         when(ccdApiClient.searchForCitizen(
@@ -132,9 +130,9 @@ class CaseServiceTest {
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
             USER_ID,
-            "test@gmail.com",
-            "Joe",
-            "Bloggs",
+            USER_EMAIL,
+            USER_FORENAME,
+            USER_SURNAME,
             null
         ));
         when(ccdApiClient.startForCitizen(
@@ -171,9 +169,9 @@ class CaseServiceTest {
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
             USER_ID,
-            "test@gmail.com",
-            "Joe",
-            "Bloggs",
+            USER_EMAIL,
+            USER_FORENAME,
+            USER_SURNAME,
             null
         ));
 
@@ -209,9 +207,9 @@ class CaseServiceTest {
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
             USER_ID,
-            "test@gmail.com",
-            "Joe",
-            "Bloggs",
+            USER_EMAIL,
+            USER_FORENAME,
+            USER_SURNAME,
             null
         ));
 

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
-import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.et.syaapi.client.CcdApiClient;
 import uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants;

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +40,8 @@ import static uk.gov.hmcts.reform.et.syaapi.utils.TestConstants.TEST_SERVICE_AUT
 class CaseServiceTest {
     private static final String CASE_TYPE = "ET_Scotland";
     private static final String CASE_ID = "TEST_CASE_ID";
+    private static final String USER_ID = "TEST_USER_ID";
+    private static final String JURISDICTION_ID = "EMPLOYMENT";
 
     private final CaseDetails expectedDetails = ResourceLoader.fromString(
         "responses/caseDetails.json",
@@ -73,8 +76,6 @@ class CaseServiceTest {
     @Mock
     private CaseDetailsConverter caseDetailsConverter;
 
-    @Mock
-    SearchResult searchResult;
 
     CaseServiceTest() throws IOException {
         // Default constructor
@@ -96,21 +97,30 @@ class CaseServiceTest {
 
     @Test
     void shouldGetCaseDetailsbyUser() {
-        searchResult.setCases(requestCaseDataList);
         String searchString = "{\"match_all\": {}}";
         Query query = new Query(QueryBuilders.wrapperQuery(searchString), 0);
 
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
-        when(ccdApiClient.searchCases(
+        when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
+            USER_ID,
+            "test@gmail.com",
+            "Joe",
+            "Bloggs",
+            null
+        ));
+        when(ccdApiClient.searchForCitizen(
             TEST_SERVICE_AUTH_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
+            USER_ID,
+            JURISDICTION_ID,
             EtSyaConstants.SCOTLAND_CASE_TYPE,
-            query.toString()
-        )).thenReturn(searchResult);
+            Collections.emptyMap()
+        )).thenReturn(requestCaseDataList);
+
 
         List<CaseDetails> expectedDataList = caseService.getCaseDataByUser(TEST_SERVICE_AUTH_TOKEN,
-                                  EtSyaConstants.SCOTLAND_CASE_TYPE, query.toString());
-        assertEquals(searchResult.getCases(), expectedDataList);
+                                  EtSyaConstants.SCOTLAND_CASE_TYPE);
+        assertEquals(requestCaseDataList, expectedDataList);
     }
 
     @Test
@@ -122,25 +132,25 @@ class CaseServiceTest {
             .build();
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
-            "12",
+            USER_ID,
             "test@gmail.com",
             "Joe",
             "Bloggs",
             null
         ));
-        when(ccdApiClient.startForCaseworker(
+        when(ccdApiClient.startForCitizen(
             TEST_SERVICE_AUTH_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
-            "12",
+            USER_ID,
             EtSyaConstants.JURISDICTION_ID,
             EtSyaConstants.SCOTLAND_CASE_TYPE,
             EtSyaConstants.DRAFT_EVENT_TYPE
         )).thenReturn(
             startEventResponse);
-        when(ccdApiClient.submitForCaseworker(
+        when(ccdApiClient.submitForCitizen(
             TEST_SERVICE_AUTH_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
-            "12",
+            USER_ID,
             EtSyaConstants.JURISDICTION_ID,
             EtSyaConstants.SCOTLAND_CASE_TYPE,
             true,
@@ -161,17 +171,17 @@ class CaseServiceTest {
     void shouldStartUpdateCaseInCcd() {
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
-            "12",
+            USER_ID,
             "test@gmail.com",
             "Joe",
             "Bloggs",
             null
         ));
 
-        when(ccdApiClient.startEventForCaseWorker(
+        when(ccdApiClient.startEventForCitizen(
             TEST_SERVICE_AUTH_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
-            "12",
+            USER_ID,
             EtSyaConstants.JURISDICTION_ID,
             EtSyaConstants.SCOTLAND_CASE_TYPE,
             CASE_ID,
@@ -199,17 +209,17 @@ class CaseServiceTest {
 
         when(authTokenGenerator.generate()).thenReturn(TEST_SERVICE_AUTH_TOKEN);
         when(idamClient.getUserDetails(TEST_SERVICE_AUTH_TOKEN)).thenReturn(new UserDetails(
-            "12",
+            USER_ID,
             "test@gmail.com",
             "Joe",
             "Bloggs",
             null
         ));
 
-        when(ccdApiClient.startEventForCaseWorker(
+        when(ccdApiClient.startEventForCitizen(
             TEST_SERVICE_AUTH_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
-            "12",
+            USER_ID,
             EtSyaConstants.JURISDICTION_ID,
             EtSyaConstants.SCOTLAND_CASE_TYPE,
             CASE_ID,
@@ -217,10 +227,10 @@ class CaseServiceTest {
         )).thenReturn(
             startEventResponse);
 
-        when(ccdApiClient.submitEventForCaseWorker(
+        when(ccdApiClient.submitEventForCitizen(
             TEST_SERVICE_AUTH_TOKEN,
             TEST_SERVICE_AUTH_TOKEN,
-            "12",
+            USER_ID,
             EtSyaConstants.JURISDICTION_ID,
             EtSyaConstants.SCOTLAND_CASE_TYPE,
             CASE_ID,


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-1731


### Change description ###
When user registers in IDAM the account would only contains the 'citizen' user role, hence it is required to update the CCD definition to include the 'citizen' role in order for the create case api to be called successfully upon logging in for new IDAM user. 

This would require updating the existing apis in sya-api for the get/create/update case calls to support 'citizen' type, so testing of these existing apis would be required.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
