### PR TITLE
2256: disable uri validation for doc upload api

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/et/syaapi/ManageCaseControllerFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/et/syaapi/ManageCaseControllerFunctionalTest.java
@@ -109,24 +109,5 @@ class ManageCaseControllerFunctionalTest extends BaseFunctionalTest {
             .assertThat().body("case_data.claimantType.claimant_email_address", equalTo(CLAIMANT_EMAIL));
     }
 
-    @Test
-    void stage5SubmitCaseShouldReturnSubmittedCaseDetails() {
-        CaseRequest caseRequest = CaseRequest.builder()
-            .caseId(caseId.toString())
-            .caseTypeId(CASE_TYPE)
-            .build();
-
-        RestAssured.given()
-            .contentType(ContentType.JSON)
-            .header(new Header(AUTHORIZATION, userToken))
-            .body(caseRequest)
-            .put("/cases/submit-case")
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .log().all(true)
-            .assertThat().body("id", equalTo(caseId))
-            .assertThat().body("state", equalTo("Submitted"));
-    }
-
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/models/CaseDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/models/CaseDocument.java
@@ -53,8 +53,8 @@ public class CaseDocument {
      * @return a boolean that is true if the document link exists
      */
     public boolean verifyUri() {
-        return links == null
+        return !(links == null
             || links.get("self") == null
-            || links.get("self").get("href") == null;
+            || links.get("self").get("href") == null);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentService.java
@@ -44,9 +44,6 @@ public class CaseDocumentService {
     private static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
     private static final String FILE_NAME_REGEX_PATTERN = "^[\\w\\- ]{1,256}+\\.[A-Za-z]{3,4}$";
     private static final Pattern FILE_NAME_PATTERN = Pattern.compile(FILE_NAME_REGEX_PATTERN);
-    private static final String HTTPS_URL_REGEX_PATTERN =
-        "^(http://www\\.|https://www\\.|http://|https://)?[\\w\\-]+(\\.[a-z]{2,5})?(:\\d{1,5})?(/.*)?$";
-    private static final Pattern HTTPS_URL_PATTERN = Pattern.compile(HTTPS_URL_REGEX_PATTERN);
     private static final String UPLOAD_FILE_EXCEPTION_MESSAGE = "Document management failed uploading file: ";
     private static final String VALIDATE_FILE_EXCEPTION_MESSAGE = "File does not pass validation";
     private final Integer maxApiRetries;
@@ -161,12 +158,7 @@ public class CaseDocumentService {
             .findFirst()
             .orElseThrow(() -> new CaseDocumentException(UPLOAD_FILE_EXCEPTION_MESSAGE + originalFilename));
 
-        if (document.verifyUri()) {
-            throw new CaseDocumentException(UPLOAD_FILE_EXCEPTION_MESSAGE + originalFilename);
-        }
-
-        Matcher matcher = HTTPS_URL_PATTERN.matcher(document.getUri().toString());
-        if (!matcher.matches()) {
+        if (!document.verifyUri()) {
             throw new CaseDocumentException(UPLOAD_FILE_EXCEPTION_MESSAGE + originalFilename);
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
@@ -38,7 +38,6 @@ class CaseDocumentServiceTest {
     private static final String CASE_TYPE = "ET_EnglandWales";
     private static final String MOCK_TOKEN = "Bearer Token";
     private static final String MOCK_HREF = "http://test:8080/img";
-    private static final String MOCK_HREF_MALFORMED = "http:/test:80/";
     private static final String EMPTY_DOCUMENT_MESSAGE = "Document management failed uploading file: " + DOCUMENT_NAME;
     private static final String SERVER_ERROR_MESSAGE = "Failed to upload Case Document";
     private static final String FILE_DOES_NOT_PASS_VALIDATION = "File does not pass validation";

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
@@ -90,8 +90,6 @@ class CaseDocumentServiceTest {
         + "\"claim-submit.png\",\"_links\":{\"self\":{}}]}";
     private static final String MOCK_RESPONSE_INCORRECT = "{\"doucments\":[{\"originalDocumentName\":"
         + "\"claim-submit.png\",\"_links\":{\"self\":{\"href\": \"" + MOCK_HREF + "\"}}}]}";
-    private static final String MOCK_RESPONSE_WITH_MALFORMED_URI = RESPONSE_BODY
-        + "\"claim-submit.png\",\"_links\":{\"self\":{\"href\": \"" + MOCK_HREF_MALFORMED + "\"}}}]}";
     private static final String MOCK_RESPONSE_WITHOUT_SELF = RESPONSE_BODY
         + "\"claim-submit.png\",\"_links\":{}}]}";
     private final String fullJsonResponse;

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
@@ -338,22 +338,6 @@ class CaseDocumentServiceTest {
     }
 
     @Test
-    void theUploadDocWhenResponseUriInvalidProducesException() {
-        mockServer.expect(ExpectedCount.max(MAX_API_CALL_ATTEMPTS), requestTo(DOCUMENT_UPLOAD_API_URL))
-            .andExpect(method(HttpMethod.POST))
-            .andRespond(withStatus(HttpStatus.OK)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(MOCK_RESPONSE_WITH_MALFORMED_URI));
-
-        CaseDocumentException documentException = assertThrows(
-            CaseDocumentException.class, () -> caseDocumentService.uploadDocument(
-                MOCK_TOKEN, CASE_TYPE, MOCK_FILE));
-
-        assertThat(documentException.getMessage())
-            .isEqualTo(EMPTY_DOCUMENT_MESSAGE);
-    }
-
-    @Test
     void theUploadDocWhenContentTypeDoesNotMatchActualFileTypeProducesDocException() {
         CaseDocumentException documentException = assertThrows(
             CaseDocumentException.class, () -> caseDocumentService.uploadDocument(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2256


### Change description ###
2256: disable uri validation for doc upload api


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
