### PR TITLE
RET-2530. Update et-data-model version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -223,7 +223,7 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLoggingVersion
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLoggingVersion
 
-  implementation group: 'com.github.hmcts', name: 'et-data-model', version: '1.0.64'
+  implementation group: 'com.github.hmcts', name: 'et-data-model', version: '1.0.65'
   implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.9.1'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '2.0.1'
   implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '4.0.3'


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RET-2530
Don't store links of hublinks, only their statuses.

Not backwards compatible but no one has used the links on the hublinks yet so it doesn't really break anything.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
