### PR TITLE
2589: make filename regex allow legal filename chars

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentService.java
@@ -54,7 +54,8 @@ import static uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants.RESOURCE_NO
 @SuppressWarnings("PMD.TooManyMethods")
 public class CaseDocumentService {
     private static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
-    private static final String FILE_NAME_REGEX_PATTERN = "^[\\w\\- ]{1,256}+\\.[A-Za-z]{3,4}$";
+    private static final String FILE_NAME_REGEX_PATTERN =
+        "^(?!\\.)(?!com\\d$)(?!con$)(?!lpt\\d$)(?!nul$)(?!prn$)[^\\|*\\?\\:<>\\/$\"]*[^\\.\\|\\*\\?\\:<>\\/$\"]+$";
     private static final Pattern FILE_NAME_PATTERN = Pattern.compile(FILE_NAME_REGEX_PATTERN);
     private static final String UPLOAD_FILE_EXCEPTION_MESSAGE = "Document management failed uploading file: ";
     private static final String VALIDATE_FILE_EXCEPTION_MESSAGE = "File does not pass validation";

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/CaseDocumentServiceTest.java
@@ -79,7 +79,7 @@ class CaseDocumentServiceTest {
 
     private static final MockMultipartFile MOCK_FILE_INVALID_NAME = new MockMultipartFile(
         "mock_file_with_invalid_name",
-        "invalid",
+        "con",
         MediaType.TEXT_PLAIN_VALUE,
         MOCK_FILE_BODY.getBytes()
     );
@@ -91,7 +91,7 @@ class CaseDocumentServiceTest {
     );
     private static final MockMultipartFile MOCK_FILE_NAME_ILLEGAL_CHAR = new MockMultipartFile(
         "mock_file_name_with_illegal_char",
-        "@invalid!|.xyz",
+        ".invalid|.xyz",
         MediaType.TEXT_PLAIN_VALUE,
         MOCK_FILE_BODY.getBytes()
     );


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2589


### Change description ###
 update filename regex in document upload allow legal filename chars


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
