### PR TITLE
RET-2731: Mock out ACAS Service tests and improve logging in et-sya-api

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasService.java
@@ -88,8 +88,8 @@ public class AcasService {
             if (attempts < MAX_ACAS_RETRIES) {
                 return attemptWithRetriesToFetchAcasCertificates(attempts + 1, acasNumbers);
             }
-            log.info("AcasCertificates retrieval for AcasNumbers: {} has failed after {} attempts with " +
-                         "the exception: {}",
+            log.info("AcasCertificates retrieval for AcasNumbers: {} has failed after {} attempts with "
+                         + "the exception: {}",
                      acasNumbers,
                      attempts,
                      e);

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasServiceTest.java
@@ -39,32 +39,26 @@ class AcasServiceTest {
     private static final String ACAS_DEV_API_URL = "https://api-dev-acas-01.azure-api.net/ECCLDev";
     private static final String ACAS_API_KEY = "dummyApiKey";
     private static final String NO_CERTS_JSON = "[]";
-    private static final String ONE_CERT_JSON =
-        "[{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}]";
-    private static final String TWO_CERTS_JSON =
-        "[{\"CertificateNumber\":\"AB123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}]";
-    private static final String THREE_CERTS_JSON =
-        "[{\"CertificateNumber\":\"AB123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}]";
 
-    private static final String FOUR_CERTS_JSON =
-        "[{\"CertificateNumber\":\"AB123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}]";
-
-    private static final String FIVE_CERTS_JSON =
-        "[{\"CertificateNumber\":\"AB123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}, " +
-            "{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW...\"}]";
+    private static final String CERT_JSON_OBJECT = "{\"CertificateNumber\":\"A123456/12/12\","
+        + "\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}";
+    private static final String ONE_CERT_JSON = "[" + CERT_JSON_OBJECT + "]";
+    private static final String TWO_CERTS_JSON = "["
+        + String.join(", ", CERT_JSON_OBJECT, CERT_JSON_OBJECT) + "]";
+    private static final String THREE_CERTS_JSON = "["
+        + String.join(", ", CERT_JSON_OBJECT, CERT_JSON_OBJECT, CERT_JSON_OBJECT) + "]";
+    private static final String FOUR_CERTS_JSON = "["
+        + String.join(", ", CERT_JSON_OBJECT, CERT_JSON_OBJECT, CERT_JSON_OBJECT, CERT_JSON_OBJECT) + "]";
+    private static final String FIVE_CERTS_JSON = "["
+        + String.join(", ", CERT_JSON_OBJECT, CERT_JSON_OBJECT, CERT_JSON_OBJECT, CERT_JSON_OBJECT,
+                      CERT_JSON_OBJECT) + "]";
     public static final String A123 = "A123";
     public static final String Z456 = "Z456";
     public static final String R123456_11_12 = "R123456/11/12";
     public static final String R123456_13_14 = "R123456/13/14";
+    public static final String R600227_21_75 = "R600227/21/75";
+    public static final String R600227_21_76 = "R600227/21/76";
+    public static final String R600227_21_77 = "R600227/21/77";
     private AcasService acasService;
     private RestTemplate restTemplate;
     private TestData testData;
@@ -269,7 +263,7 @@ class AcasServiceTest {
     void theGetAcasCertWithBadApiKeyFirstTimeProducesCertificates()
         throws AcasException, InvalidAcasNumbersException {
         JSONObject expectedBody = new JSONObject();
-        expectedBody.put("certificateNumbers", List.of("R123456/11/12","R123456/13/14"));
+        expectedBody.put("certificateNumbers", List.of(R123456_11_12, R123456_13_14));
         getMockServer().expect(ExpectedCount.times(2), requestTo(ACAS_DEV_API_URL))
             .andExpect(method(HttpMethod.POST))
             .andExpect(r -> {
@@ -289,8 +283,8 @@ class AcasServiceTest {
     void theGetAcasCertificatesByCaseDataProducesTwoAcasCertificates() throws
         AcasException, InvalidAcasNumbersException {
         JSONObject expectedBody = new JSONObject();
-        expectedBody.put("certificateNumbers", List.of("R600227/21/75","R600227/21/76",
-                                                       "R600227/21/77", "R600227/21/77","R600227/21/77"));
+        expectedBody.put("certificateNumbers", List.of(R600227_21_75, R600227_21_76,
+                                                       R600227_21_77, R600227_21_77, R600227_21_77));
 
         getMockServer().expect(ExpectedCount.times(2), requestTo(ACAS_DEV_API_URL))
             .andExpect(method(HttpMethod.POST))
@@ -329,7 +323,7 @@ class AcasServiceTest {
         testData.getCaseData().getRespondentCollection().get(0).setValue(null);
         testData.getCaseData().getRespondentCollection().get(1).setValue(null);
         JSONObject expectedBody = new JSONObject();
-        expectedBody.put("certificateNumbers", List.of("R600227/21/77","R600227/21/77","R600227/21/77"));
+        expectedBody.put("certificateNumbers", List.of(R600227_21_77, R600227_21_77, R600227_21_77));
 
         getMockServer().expect(ExpectedCount.times(2), requestTo(ACAS_DEV_API_URL))
             .andExpect(method(HttpMethod.POST))

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasServiceTest.java
@@ -36,7 +36,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 class AcasServiceTest {
 
     private static final String ACAS_DEV_API_URL = "https://api-dev-acas-01.azure-api.net/ECCLDev";
-    private static final String ACAS_API_KEY = "ecd18c987120415b95f60b844e6730ef";
+    private static final String ACAS_API_KEY = "dummyApiKey";
     private static final String NO_CERTS_JSON = "[]";
     private static final String ONE_CERT_JSON =
         "[{\"CertificateNumber\":\"A123456/12/12\",\"CertificateDocument\":\"JVBERi0xLjcNCiW1tbW1...\"}]";

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.et.syaapi.service;
 
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -279,7 +278,6 @@ class AcasServiceTest {
     }
 
     @Test
-    @Disabled("Awaiting to be refactored")
     void theGetAcasCertificatesByCaseDataProducesTwoAcasCertificates() throws
         AcasException, InvalidAcasNumbersException {
         JSONObject expectedBody = new JSONObject();
@@ -316,7 +314,6 @@ class AcasServiceTest {
         assertThat(acasCertificates).isEmpty();
     }
 
-    @Disabled("Awaiting to be refactored")
     @Test
     void theGetAcasCertificatesByCaseDataDoesNotProduceAcasCertificatesWhenNullRespondentSumTypeItem() throws
         AcasException, InvalidAcasNumbersException {
@@ -340,7 +337,6 @@ class AcasServiceTest {
         assertThat(acasCertificates).hasSize(3);
     }
 
-    @Disabled("Awaiting to be refactored")
     @Test
     void theGetAcasCertificatesByCaseDataDoesNotProduceAcasCertificatesWhenEmptyRespondentSumTypeItem() throws
         AcasException, InvalidAcasNumbersException {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2731


### Change description ###
The ACAS Service tests call off to the live ACAS service. This should be changed so that the response from ACAS is mocked so we are not using any live services or using any keys which have been provided by ACAS. If we want to call off to the live service, we should be using environment variables and be putting these tests in Integration tests.

We should also look to improve logging around the ACAS interaction as it can cause the UI to show there is an issue but it submits the case. We should see if we can interact with the endpoint before doing and requests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
