### PR TITLE
RET-2918 BUG: ET1 vetting work address showing as null

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AssignCaseToLocalOfficeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AssignCaseToLocalOfficeService.java
@@ -9,6 +9,7 @@ import uk.gov.dwp.regex.InvalidPostcodeException;
 import uk.gov.hmcts.ecm.common.model.helper.TribunalOffice;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
 import uk.gov.hmcts.et.common.model.ccd.items.RespondentSumTypeItem;
+import uk.gov.hmcts.et.common.model.ccd.types.ClaimantWorkAddressType;
 import uk.gov.hmcts.reform.et.syaapi.helper.EmployeeObjectMapper;
 import uk.gov.hmcts.reform.et.syaapi.models.CaseRequest;
 
@@ -37,10 +38,14 @@ public class AssignCaseToLocalOfficeService {
             managingOffice = getManagingOffice(
                 caseData.getClaimantWorkAddress().getClaimantWorkAddress().getPostCode());
         } else if (!CollectionUtils.isEmpty(respondentSumTypeList)) {
+            ClaimantWorkAddressType claimantWorkAddressType = new ClaimantWorkAddressType();
             for (RespondentSumTypeItem respondentSumTypeItem : respondentSumTypeList) {
                 if (respondentSumTypeItem.getValue() != null
                     && respondentSumTypeItem.getValue().getRespondentAddress() != null
                     && StringUtils.isNotBlank(respondentSumTypeItem.getValue().getRespondentAddress().getPostCode())) {
+                    claimantWorkAddressType.setClaimantWorkAddress(
+                        respondentSumTypeItem.getValue().getRespondentAddress());
+                    caseData.setClaimantWorkAddress(claimantWorkAddressType);
                     managingOffice = getManagingOffice(
                         respondentSumTypeItem.getValue().getRespondentAddress().getPostCode());
                     break;

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AssignCaseToLocalOfficeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AssignCaseToLocalOfficeService.java
@@ -41,14 +41,15 @@ public class AssignCaseToLocalOfficeService {
             ClaimantWorkAddressType claimantWorkAddressType = new ClaimantWorkAddressType();
             for (RespondentSumTypeItem respondentSumTypeItem : respondentSumTypeList) {
                 if (respondentSumTypeItem.getValue() != null
-                    && respondentSumTypeItem.getValue().getRespondentAddress() != null
-                    && StringUtils.isNotBlank(respondentSumTypeItem.getValue().getRespondentAddress().getPostCode())) {
+                    && respondentSumTypeItem.getValue().getRespondentAddress() != null) {
                     claimantWorkAddressType.setClaimantWorkAddress(
                         respondentSumTypeItem.getValue().getRespondentAddress());
                     caseData.setClaimantWorkAddress(claimantWorkAddressType);
-                    managingOffice = getManagingOffice(
-                        respondentSumTypeItem.getValue().getRespondentAddress().getPostCode());
-                    break;
+                    if (StringUtils.isNotBlank(respondentSumTypeItem.getValue().getRespondentAddress().getPostCode())) {
+                        managingOffice = getManagingOffice(
+                            respondentSumTypeItem.getValue().getRespondentAddress().getPostCode());
+                        break;
+                    }
                 }
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AssignCaseToLocalOfficeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AssignCaseToLocalOfficeService.java
@@ -41,15 +41,14 @@ public class AssignCaseToLocalOfficeService {
             ClaimantWorkAddressType claimantWorkAddressType = new ClaimantWorkAddressType();
             for (RespondentSumTypeItem respondentSumTypeItem : respondentSumTypeList) {
                 if (respondentSumTypeItem.getValue() != null
-                    && respondentSumTypeItem.getValue().getRespondentAddress() != null) {
+                    && respondentSumTypeItem.getValue().getRespondentAddress() != null
+                    && StringUtils.isNotBlank(respondentSumTypeItem.getValue().getRespondentAddress().getPostCode())) {
                     claimantWorkAddressType.setClaimantWorkAddress(
                         respondentSumTypeItem.getValue().getRespondentAddress());
                     caseData.setClaimantWorkAddress(claimantWorkAddressType);
-                    if (StringUtils.isNotBlank(respondentSumTypeItem.getValue().getRespondentAddress().getPostCode())) {
-                        managingOffice = getManagingOffice(
-                            respondentSumTypeItem.getValue().getRespondentAddress().getPostCode());
-                        break;
-                    }
+                    managingOffice = getManagingOffice(
+                        respondentSumTypeItem.getValue().getRespondentAddress().getPostCode());
+                    break;
                 }
             }
         }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RET-2918

### Change description ###

Added new lines to AssignCaseToLocalOfficeService.java.
if there is any respondent and no claimant work address is entered we fill the work address of claimant as the address of the respondent.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
