### PR TITLE
RET-2289: Et-common version bump to 1.0.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ ext {
 }
 
 dependencies {
-  implementation('com.github.hmcts:et-common:1.0.6') { transitive = false }
+  implementation('com.github.hmcts:et-common:1.0.11') { transitive = false }
   implementation group: 'uk.gov.dwp.regex', name: 'postcode-validation', version: '1.1.0'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.5', {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2289


### Change description ###
Bump et-common version to 1.0.11


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
