### PR TITLE
values removed by error added back

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseService.java
@@ -200,6 +200,10 @@ public class CaseService {
         //  and add it to our pdf files list
         caseData.setEthosCaseReference(caseDetails.getData().get("ethosCaseReference") == null ? "" :
                                            caseDetails.getData().get("ethosCaseReference").toString());
+        caseData.setReceiptDate(caseDetails.getData().get("receiptDate") == null ? "" :
+                                    caseDetails.getData().get("receiptDate").toString());
+        caseData.setFeeGroupReference(caseDetails.getData().get("feeGroupReference") == null ? "" :
+                                          caseDetails.getData().get("feeGroupReference").toString());
 
         UserInfo userInfo = idamClient.getUserInfo(authorization);
         List<PdfDecodedMultipartFile> casePdfFiles =


### PR DESCRIPTION
Code that sets the values of receiptDate and feeGroupReference was removed by mistake in the previous pr and now adde in back. 

https://tools.hmcts.net/jira/browse/RET-3168


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
