### PR TITLE
Fixing Java 8 LocalDateTime parse issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ dependencies {
   }
 
   implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
-
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/helper/EmployeeObjectMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/helper/EmployeeObjectMapper.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.et.syaapi.helper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
@@ -24,6 +25,7 @@ public class EmployeeObjectMapper {
      */
     public Et1CaseData getEmploymentCaseData(String caseData) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
         Et1CaseData data = null;
         try {
             data = mapper.readValue(caseData, Et1CaseData.class);
@@ -41,11 +43,13 @@ public class EmployeeObjectMapper {
      */
     public Et1CaseData getEmploymentCaseData(Map<String, Object> caseData) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
         return mapper.convertValue(caseData, Et1CaseData.class);
     }
 
     private static CaseData getCaseData(Map<String, Object> caseData) {
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
         return mapper.convertValue(caseData, CaseData.class);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/CaseService.java
@@ -54,7 +54,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static uk.gov.hmcts.ecm.common.model.helper.Constants.MAX_ES_SIZE;
@@ -434,7 +433,7 @@ public class CaseService {
                                                 d.getValue().getTypeOfDocument(),
                                                 ""
                                             )))
-                                            .collect(toList()));
+                                            .toList());
 
             if (caseData.getClaimantRequests() != null
                 && caseData.getClaimantRequests().getClaimDescriptionDocument() != null) {


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Added a new jackson library to resolve the error below. 

Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.IllegalArgumentException: Java 8 date/time type `java.time.LocalDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: uk.gov.hmcts.et.common.model.ccd.CaseData["changeOrganisationRequestField"]->uk.gov.hmcts.et.common.model.ccd.types.ChangeOrganisationRequest$ChangeOrganisationRequestBuilder["RequestTimestamp"])] with root cause

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
