### PR TITLE
Update tagEnv to use production instead of prod

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,7 +3,7 @@ provider "azurerm" {
 }
 
 locals {
-  tagEnv = var.env == "aat" ? "staging" : var.env == "perftest" ? "testing" : var.env
+  tagEnv = var.env == "aat" ? "staging" : var.env == "perftest" ? "testing" : var.env == "prod" ? "production" : var.env
   tags = merge(var.common_tags,
     tomap({
       "environment"  = local.tagEnv,


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Update tagEnv for production as 'prod' is not a valid value - see https://github.com/hmcts/azure-policy/blob/master/policies/tagging/README.md
Logic where env = prod, set the tagEnv to production

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
