### PR TITLE
RET-5973

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/SyaApiApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/SyaApiApplication.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.et.syaapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
 import uk.gov.hmcts.reform.ccd.client.CaseAssignmentApi;
@@ -22,6 +23,7 @@ import uk.gov.hmcts.reform.idam.client.IdamApi;
         CaseAssignmentApi.class,
     }
 )
+@EnableCaching
 public class SyaApiApplication {
 
     public static void main(final String[] args) {

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasController.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasController.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.et.syaapi.controllers;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
@@ -16,9 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.et.syaapi.annotation.ApiResponseGroup;
 import uk.gov.hmcts.reform.et.syaapi.models.CaseDocumentAcasResponse;
 import uk.gov.hmcts.reform.et.syaapi.service.AcasCaseService;
+import uk.gov.hmcts.reform.et.syaapi.service.AdminUserService;
 import uk.gov.hmcts.reform.et.syaapi.service.CaseDocumentService;
 import uk.gov.hmcts.reform.et.syaapi.service.FeatureToggleService;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,13 +37,8 @@ public class AcasController {
 
     private final AcasCaseService acasCaseService;
     private final CaseDocumentService caseDocumentService;
-    private final IdamClient idamClient;
+    private final AdminUserService adminUserService;
     private final FeatureToggleService featureToggleService;
-
-    @Value("${caseWorkerUserName}")
-    private String caseWorkerUserName;
-    @Value("${caseWorkerPassword}")
-    private String caseWorkerPassword;
 
     /**
      * Given a datetime, this method will return a list of caseIds which have been modified since the datetime
@@ -111,7 +105,7 @@ public class AcasController {
     public ResponseEntity<ByteArrayResource> getDocumentBinaryContent(
         @RequestParam(name = "documentId") final UUID documentId,
         @RequestHeader(AUTHORIZATION) String authToken) {
-        String accessToken = idamClient.getAccessToken(caseWorkerUserName, caseWorkerPassword);
+        String accessToken = adminUserService.getAdminUserToken();
         return caseDocumentService.downloadDocument(accessToken, documentId);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.et.common.model.ccd.CaseData;
@@ -57,14 +56,10 @@ public class AcasCaseService {
 
     private final AuthTokenGenerator authTokenGenerator;
     private final CoreCaseDataApi ccdApiClient;
+    private final AdminUserService adminUserService;
     private final IdamClient idamClient;
     private final CaseDocumentService caseDocumentService;
     private final TaskExecutor taskExecutor;
-
-    @Value("${caseWorkerUserName}")
-    private String caseWorkerUserName;
-    @Value("${caseWorkerPassword}")
-    private String caseWorkerPassword;
 
     /**
      * Given a datetime, this method will return a list of caseIds which have been modified since the datetime
@@ -139,7 +134,7 @@ public class AcasCaseService {
     }
 
     private List<CaseDocumentAcasResponse> getDocumentUuids(String query) {
-        String authorisation = idamClient.getAccessToken(caseWorkerUserName, caseWorkerPassword);
+        String authorisation = adminUserService.getAdminUserToken();
         List<CaseData> caseDataList = searchAndReturnCaseDataList(authorisation, query);
 
         List<CaseDocumentAcasResponse> documents = new ArrayList<>();
@@ -340,7 +335,7 @@ public class AcasCaseService {
      * @return the case details
      */
     public CaseDetails vetAndAcceptCase(String caseId) {
-        String authorization = idamClient.getAccessToken(caseWorkerUserName, caseWorkerPassword);
+        String authorization = adminUserService.getAdminUserToken();
         CaseDetails caseDetails = ccdApiClient.getCase(authorization, authTokenGenerator.generate(), caseId);
         if (ObjectUtils.isEmpty(caseDetails)) {
             throw new IllegalArgumentException("Case not found");

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AdminUserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AdminUserService.java
@@ -4,13 +4,42 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 
+/**
+ * Service responsible for obtaining and caching an admin user token used for API calls.
+ *
+ * <p>
+ * This service retrieves an authentication token from the {@link IdamClient} using the configured
+ * caseworker credentials. The token is cached to reduce the number of authentication requests
+ * sent to IDAM. The cache is cleared at a fixed interval, ensuring that the token is periodically
+ * refreshed in line with its time-to-live (TTL).
+ * </p>
+ *
+ * <h2>Configuration</h2>
+ * <ul>
+ *   <li><b>caseWorkerUserName</b>: Username for the case worker user.</li>
+ *   <li><b>caseWorkerPassword</b>: Password for the case worker user.</li>
+ *   <li><b>caching.adminUserTokenTTL</b>: Interval in milliseconds for scheduled cache eviction.</li>
+ * </ul>
+ *
+ * <h2>Caching</h2>
+ * The admin user token is cached under the {@code adminUserToken} cache name. It is automatically
+ * evicted according to the configured TTL.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@CacheConfig(cacheNames = {"adminUserToken"})
 public class AdminUserService {
+    /**
+     * Constant prefix for bearer tokens.
+     */
     public static final String BEARER = "Bearer";
     private final IdamClient idamClient;
 
@@ -20,11 +49,36 @@ public class AdminUserService {
     @Value("${caseWorkerPassword}")
     private String apiCallUserPassword;
 
+    /**
+     * Retrieves the admin user access token from IDAM.
+     *
+     * <p>
+     * If the token does not already include the {@code Bearer} prefix, it is prepended before
+     * returning. The result is cached to avoid repeated calls to the IDAM service.
+     * </p>
+     *
+     * @return a valid admin user bearer token
+     */
+    @Cacheable("adminUserToken")
     public String getAdminUserToken() {
         String adminAccessToken = idamClient.getAccessToken(apiCallUserName, apiCallUserPassword);
         if (StringUtils.contains(adminAccessToken, BEARER)) {
             return adminAccessToken;
         }
         return String.join(" ", BEARER, adminAccessToken);
+    }
+
+    /**
+     * Clears the cached admin user token at a fixed interval.
+     *
+     * <p>
+     * This method runs according to the schedule defined by {@code caching.adminUserTokenTTL}.
+     * It ensures that the cached token does not exceed its intended time-to-live (TTL).
+     * </p>
+     */
+    @CacheEvict(value = "adminUserToken", allEntries = true)
+    @Scheduled(fixedRateString = "${caching.adminUserTokenTTL}")
+    public void emptyAdminUserToken() {
+        log.info("emptying adminUserToken cache");
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AdminUserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/et/syaapi/service/AdminUserService.java
@@ -23,8 +23,8 @@ import uk.gov.hmcts.reform.idam.client.IdamClient;
  *
  * <h2>Configuration</h2>
  * <ul>
- *   <li><b>caseWorkerUserName</b>: Username for the case worker user.</li>
- *   <li><b>caseWorkerPassword</b>: Password for the case worker user.</li>
+ *   <li><b>caseWorkerUserName</b>: Username for the caseworker user.</li>
+ *   <li><b>caseWorkerPassword</b>: Password for the caseworker user.</li>
  *   <li><b>caching.adminUserTokenTTL</b>: Interval in milliseconds for scheduled cache eviction.</li>
  * </ul>
  *

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -149,3 +149,6 @@ launchdarkly:
   env: ${LAUNCH_DARKLY_ENV:default}
 
 assign_case_access_api_url: ${AAC_URL:http://localhost:4454}
+
+caching:
+  adminUserTokenTTL: ${ADMIN_USER_TOKEN_TTL:21600000}

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/controllers/AcasControllerTest.java
@@ -20,10 +20,10 @@ import uk.gov.hmcts.reform.et.syaapi.SyaApiApplication;
 import uk.gov.hmcts.reform.et.syaapi.constants.EtSyaConstants;
 import uk.gov.hmcts.reform.et.syaapi.models.CaseDocumentAcasResponse;
 import uk.gov.hmcts.reform.et.syaapi.service.AcasCaseService;
+import uk.gov.hmcts.reform.et.syaapi.service.AdminUserService;
 import uk.gov.hmcts.reform.et.syaapi.service.CaseDocumentService;
 import uk.gov.hmcts.reform.et.syaapi.service.FeatureToggleService;
 import uk.gov.hmcts.reform.et.syaapi.service.VerifyTokenService;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -65,7 +65,7 @@ class AcasControllerTest {
     private CaseDocumentService caseDocumentService;
 
     @MockBean
-    private IdamClient idamClient;
+    private AdminUserService adminUserService;
 
     private MockMvc mockMvc;
 
@@ -191,7 +191,7 @@ class AcasControllerTest {
     @Test
     void downloadAcasDocumentsDocumentsFound() throws Exception {
         when(verifyTokenService.verifyTokenSignature(AUTH_TOKEN)).thenReturn(true);
-        when(idamClient.getAccessToken(anyString(), anyString())).thenReturn(AUTH_TOKEN);
+        when(adminUserService.getAdminUserToken()).thenReturn(AUTH_TOKEN);
         when(caseDocumentService.downloadDocument(anyString(), any())).thenReturn(getDocumentBinaryContent());
         mockMvc.perform(get(DOWNLOAD_ACAS_DOCUMENTS_URL)
                             .header(HttpHeaders.AUTHORIZATION, AUTH_TOKEN)

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AcasCaseServiceTest.java
@@ -58,6 +58,8 @@ class AcasCaseServiceTest {
     @Mock
     private IdamClient idamClient;
     @Mock
+    private AdminUserService adminUserService;
+    @Mock
     private CaseDocumentService caseDocumentService;
     @Mock
     private TaskExecutor taskExecutor;
@@ -73,7 +75,7 @@ class AcasCaseServiceTest {
     @BeforeEach
     void setUp() {
         when(authTokenGenerator.generate()).thenReturn(TestConstants.TEST_SERVICE_AUTH_TOKEN);
-        lenient().when(idamClient.getAccessToken(any(), any())).thenReturn(TestConstants.TEST_SERVICE_AUTH_TOKEN);
+        lenient().when(adminUserService.getAdminUserToken()).thenReturn(TestConstants.TEST_SERVICE_AUTH_TOKEN);
         lenient().doAnswer(invocation -> {
             ((Runnable) invocation.getArgument(0)).run();
             return null;
@@ -316,7 +318,7 @@ class AcasCaseServiceTest {
                 argumentCaptor.capture());
 
         // Check Vetting Data
-        CaseData caseData = (CaseData) argumentCaptor.getAllValues().get(0).getData();
+        CaseData caseData = (CaseData) argumentCaptor.getAllValues().getFirst().getData();
         assertThat(caseData.getAreTheseCodesCorrect()).isEqualTo(TestConstants.YES);
         assertThat(caseData.getEt1VettingCanServeClaimYesOrNo()).isEqualTo(TestConstants.YES);
         // Check Pre Acceptance Data

--- a/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AdminUserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/et/syaapi/service/AdminUserServiceTest.java
@@ -1,0 +1,92 @@
+package uk.gov.hmcts.reform.et.syaapi.service;
+
+import org.apache.commons.lang3.math.NumberUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AdminUserServiceTest {
+
+    private static final String PARAM_CASEWORKER_USERNAME = "caseWorkerUserName=";
+    private static final String CASEWORKER_USERNAME = "caseworker@hmcts.com";
+    private static final String PARAM_CASEWORKER_PASSWORD = "caseWorkerPassword=";
+    private static final String CASEWORKER_PASSWORD = "caseWorkerPassword";
+    private static final String CONFIG_ADMIN_USER_TOKEN_TTL = "caching.adminUserTokenTTL=";
+    private static final String ADMIN_USER_TTL = "60000";
+    private static final String CACHE_NAME_ADMIN_USER_TOKEN = "adminUserToken";
+    private static final String TOKEN_1 = "dummyToken1";
+    private static final String TOKEN_2 = "dummyToken2";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final ApplicationContextRunner contextRunner =
+        new ApplicationContextRunner()
+            .withUserConfiguration(TestConfig.class)
+            .withInitializer(ctx ->
+                                 TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+                                     ctx,
+                                     PARAM_CASEWORKER_USERNAME + CASEWORKER_USERNAME,
+                                     PARAM_CASEWORKER_PASSWORD + CASEWORKER_PASSWORD,
+                                     CONFIG_ADMIN_USER_TOKEN_TTL + ADMIN_USER_TTL
+                                 )
+            );
+
+    @Configuration
+    @EnableCaching
+    static class TestConfig {
+
+        @Bean
+        IdamClient idamClient() {
+            return Mockito.mock(IdamClient.class);
+        }
+
+        @Bean
+        CacheManager cacheManager() {
+            return new ConcurrentMapCacheManager(CACHE_NAME_ADMIN_USER_TOKEN);
+        }
+
+        @Bean
+        AdminUserService adminUserService(IdamClient idamClient) {
+            return new AdminUserService(idamClient);
+        }
+    }
+
+    @Test
+    void cacheShouldAvoidSecondCallAndEvictOnEmpty() {
+        contextRunner.run(ctx -> {
+            AdminUserService service = ctx.getBean(AdminUserService.class);
+            IdamClient idam = ctx.getBean(IdamClient.class);
+
+            when(idam.getAccessToken(CASEWORKER_USERNAME, CASEWORKER_PASSWORD))
+                .thenReturn(TOKEN_1) // would be used for first call
+                .thenReturn(TOKEN_2); // would be used only after eviction
+
+            // 1) First call -> calls IDAM and caches return value
+            String t1 = service.getAdminUserToken();
+            assertThat(t1).isEqualTo(BEARER_PREFIX + TOKEN_1);
+            verify(idam, times(NumberUtils.INTEGER_ONE)).getAccessToken(CASEWORKER_USERNAME, CASEWORKER_PASSWORD);
+
+            // 2) Second call -> should come from cache; not calls IDAM
+            String t2 = service.getAdminUserToken();
+            assertThat(t2).isEqualTo(BEARER_PREFIX + TOKEN_1);
+            verify(idam, times(NumberUtils.INTEGER_ONE)).getAccessToken(CASEWORKER_USERNAME, CASEWORKER_PASSWORD);
+
+            // 3) Evict cache, then call again -> calls IDAM second time
+            service.emptyAdminUserToken();
+            String t3 = service.getAdminUserToken();
+            assertThat(t3).isEqualTo(BEARER_PREFIX + TOKEN_2);
+            verify(idam, times(NumberUtils.INTEGER_TWO)).getAccessToken(CASEWORKER_USERNAME, CASEWORKER_PASSWORD);
+        });
+    }
+}


### PR DESCRIPTION
<h1> JIRA link (if applicable) </h1>

https://tools.hmcts.net/jira/browse/RET-5973 

<h1> Change description </h1>

<h3 data-start="184" data-end="196">Overview</h3>
<p data-start="197" data-end="461">This PR enhances the <strong data-start="218" data-end="238">AdminUserService</strong> by introducing robust, annotation-driven caching. It ensures that admin tokens are efficiently reused and automatically refreshed, while also stabilizing the functional test environment with consistent cache configuration.</p>
<h3 data-start="463" data-end="488">🆕 Changes Introduced</h3>
<h4 data-start="490" data-end="528">Admin Token Caching Enhancements</h4>
<ul data-start="529" data-end="909">
<li data-start="529" data-end="640">
<p data-start="531" data-end="640">Annotated <code data-start="541" data-end="562">getAdminUserToken()</code> with <code data-start="568" data-end="598">@Cacheable("adminUserToken")</code> to reuse tokens and reduce calls to IDAM.</p>
</li>
<li data-start="641" data-end="843">
<p data-start="643" data-end="843">Configured <code data-start="654" data-end="677">emptyAdminUserToken()</code> with <code data-start="683" data-end="741">@CacheEvict(value = "adminUserToken", allEntries = true)</code> and <code data-start="746" data-end="808">@Scheduled(fixedRateString = "${caching.adminUserTokenTTL}")</code> to regularly invalidate the cache.</p>
</li>
<li data-start="844" data-end="909">
<p data-start="846" data-end="909">Ensured tokens are always prefixed with <code data-start="886" data-end="896">"Bearer"</code> when absent.</p>
</li>
</ul>
<h4 data-start="911" data-end="942">Functional Test Stability</h4>
<ul data-start="943" data-end="1198">
<li data-start="943" data-end="1119">
<p data-start="945" data-end="1119">Introduced <strong data-start="956" data-end="975">TestCacheConfig</strong> (test-only) that registers a <code data-start="1005" data-end="1032">ConcurrentMapCacheManager</code> with <code data-start="1038" data-end="1056">"adminUserToken"</code> pre-configured, preventing startup errors in functional tests.</p>
</li>
<li data-start="1120" data-end="1198">
<p data-start="1122" data-end="1198">Updated functional test base configuration to include this test cache setup.</p>
</li>
</ul>
<h4 data-start="1200" data-end="1231">Configuration Adjustments</h4>
<ul data-start="1232" data-end="1465">
<li data-start="1232" data-end="1351">
<p data-start="1234" data-end="1351">Extended <code data-start="1243" data-end="1261">application.yaml</code> and test-specific config files to include required caching TTL and scheduling properties.</p>
</li>
<li data-start="1352" data-end="1465">
<p data-start="1354" data-end="1465">Aligned configuration values between production and functional test environments (<code data-start="1436" data-end="1463">caching.adminUserTokenTTL</code>).</p>
</li>
</ul>
<h3 data-start="1467" data-end="1501">Architecture &amp; Files Affected</h3>
<div class="_tableContainer_1rjym_1"><div tabindex="-1" class="_tableWrapper_1rjym_13 group flex w-fit flex-col-reverse">
Component | Description
-- | --
AdminUserService | Now uses @Cacheable and scheduled @CacheEvict to manage token caching and refresh.
TestCacheConfig | Provides an in-memory cache manager for functional tests.
Functional Test Base Class | Updated to load the test cache configuration and avoid cache-not-found issues.
application.yaml & test config | Updated to include caching-related properties and ensure scheduling is supported.

</div></div>
<h3 data-start="1997" data-end="2009">Testing</h3>
<ul data-start="2011" data-end="2301">
<li data-start="2011" data-end="2183">
<p data-start="2013" data-end="2039"><strong data-start="2013" data-end="2027">Unit tests</strong> now verify:</p>
<ul data-start="2042" data-end="2183">
<li data-start="2042" data-end="2086">
<p data-start="2044" data-end="2086">The token is cached after the first fetch.</p>
</li>
<li data-start="2089" data-end="2135">
<p data-start="2091" data-end="2135">Cache eviction triggers new token retrieval.</p>
</li>
<li data-start="2138" data-end="2183">
<p data-start="2140" data-end="2183"><code data-start="2140" data-end="2150">"Bearer"</code> prefix is enforced consistently.</p>
</li>
</ul>
</li>
<li data-start="2184" data-end="2301">
<p data-start="2186" data-end="2301"><strong data-start="2186" data-end="2206">Functional tests</strong> boot cleanly with a valid cache in the Spring context, avoiding prior initialization failures.</p>
</li>
</ul>
<h3 data-start="2303" data-end="2325">Benefits &amp; Impact</h3>
<ul data-start="2327" data-end="2618">
<li data-start="2327" data-end="2413">
<p data-start="2329" data-end="2413"><strong data-start="2329" data-end="2344">Performance</strong>: Reduces redundant token retrievals by leveraging in-memory caching.</p>
</li>
<li data-start="2414" data-end="2515">
<p data-start="2416" data-end="2515"><strong data-start="2416" data-end="2431">Reliability</strong>: Ensures tokens are refreshed automatically — complies with token TTL requirements.</p>
</li>
<li data-start="2516" data-end="2618">
<p data-start="2518" data-end="2618"><strong data-start="2518" data-end="2536">Test Stability</strong>: Functional tests now run without configuration errors, improving pipeline trust.</p>
</li>
</ul>
<h3 data-start="2620" data-end="2647">Backward Compatibility</h3>
<ul data-start="2648" data-end="2924">
<li data-start="2648" data-end="2741">
<p data-start="2650" data-end="2741"><strong data-start="2650" data-end="2673">No breaking changes</strong>. The token API remains unchanged from the perspective of consumers.</p>
</li>
<li data-start="2742" data-end="2924">
<p data-start="2744" data-end="2772"><strong data-start="2744" data-end="2771">Release note suggestion</strong>:</p>
<blockquote data-start="2775" data-end="2924">
<p data-start="2777" data-end="2924">“Enhance AdminUserService with caching and scheduled eviction of admin tokens; functional tests now support proper in-memory cache initialization.”</p></blockquote></li></ul>

<h2>Does this PR introduce a breaking change? (check one with "x") </h2>

```
[ ] Yes
[X] No
```
